### PR TITLE
fix(audio): persist ScriptableObject sound assignments

### DIFF
--- a/Assets/Prefabs/Sounds.asset
+++ b/Assets/Prefabs/Sounds.asset
@@ -13,6 +13,11 @@ MonoBehaviour:
   m_Name: Sounds
   m_EditorClassIdentifier: 
   m_Sounds:
-  - {fileID: 8300000, guid: 7c0d0e0a936a34b409f2f7848c626ff0, type: 3}
-  - {fileID: 8300000, guid: 791b30b631a60dd4a86f40ab0a59de25, type: 3}
   - {fileID: 8300000, guid: 5db4259079725c8409aac568d3a25a96, type: 3}
+  - {fileID: 8300000, guid: 791b30b631a60dd4a86f40ab0a59de25, type: 3}
+  - {fileID: 8300000, guid: 8be088a1084b58c4bb5977c8fd4bc050, type: 3}
+  - {fileID: 8300000, guid: 866c8109299dae14a874f273a580ccba, type: 3}
+  - {fileID: 8300000, guid: 084fd99aeace6ae4a8250c7210e78bf9, type: 3}
+  - {fileID: 8300000, guid: a41e9319024fb2149b1ed99d83ff86c3, type: 3}
+  - {fileID: 8300000, guid: 84cc71bef90492f4090e754822ef6c00, type: 3}
+  - {fileID: 8300000, guid: 7c0d0e0a936a34b409f2f7848c626ff0, type: 3}

--- a/Assets/Scenes/Level_1.unity
+++ b/Assets/Scenes/Level_1.unity
@@ -1564,7 +1564,7 @@ MonoBehaviour:
   - squads:
     - asset: {fileID: 11400000, guid: 72cf142ae2b40ea49a5eaed25bc8966f, type: 2}
       count: 3
-  prepareTime: 7
+  prepareTime: 6
   next: {fileID: 1006857779}
 --- !u!1 &796081990
 GameObject:
@@ -1931,7 +1931,7 @@ MonoBehaviour:
       count: 0
     - asset: {fileID: 11400000, guid: ed3b56a26de293d4ba17f8d2c3cf1c54, type: 2}
       count: 3
-  prepareTime: 8
+  prepareTime: 7
   next: {fileID: 1541547533}
 --- !u!1 &1026400134
 GameObject:
@@ -2951,7 +2951,7 @@ MonoBehaviour:
   - squads:
     - asset: {fileID: 11400000, guid: 72cf142ae2b40ea49a5eaed25bc8966f, type: 2}
       count: 4
-  prepareTime: 9
+  prepareTime: 8
   next: {fileID: 0}
 --- !u!1 &1549901565
 GameObject:
@@ -4251,6 +4251,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 68135023606258546, guid: 1a93c6b7b991e844e897a654f5a972e6, type: 3}
+      propertyPath: m_IgnoreReversedGraphics
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1266441087970315265, guid: 1a93c6b7b991e844e897a654f5a972e6, type: 3}
       propertyPath: m_Name
       value: MisClick
@@ -4267,6 +4271,14 @@ PrefabInstance:
       propertyPath: m_Camera
       value: 
       objectReference: {fileID: 519420031}
+    - target: {fileID: 5673923774718451474, guid: 1a93c6b7b991e844e897a654f5a972e6, type: 3}
+      propertyPath: m_RenderMode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5673923774718451474, guid: 1a93c6b7b991e844e897a654f5a972e6, type: 3}
+      propertyPath: m_PixelPerfect
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7531301124779811648, guid: 1a93c6b7b991e844e897a654f5a972e6, type: 3}
       propertyPath: m_Pivot.x
       value: 0

--- a/Assets/Scenes/Level_2.unity
+++ b/Assets/Scenes/Level_2.unity
@@ -3809,9 +3809,21 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3626054808841272343, guid: 765bf152c03dea04a94e4930ad4693d7, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4534007163366116183, guid: 765bf152c03dea04a94e4930ad4693d7, type: 3}
       propertyPath: m_Name
       value: HUD
+      objectReference: {fileID: 0}
+    - target: {fileID: 6539865391095448097, guid: 765bf152c03dea04a94e4930ad4693d7, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7789244014826262421, guid: 765bf152c03dea04a94e4930ad4693d7, type: 3}
+      propertyPath: m_DoNotDestroyOnLoad
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scripts/Sounds/Sounds.cs
+++ b/Assets/Scripts/Sounds/Sounds.cs
@@ -27,9 +27,16 @@ namespace TowerDefense
                 }
                 for(int i = 0; i < target.m_Sounds.Length; i++) //Так как этот класс является внутренним классом класса Sounds, то он имеет доступ к его приватным переменным. 
                 {
-                    target.m_Sounds[i] = EditorGUILayout.ObjectField($"{(Sound)i}:", 
+                    var newClip = EditorGUILayout.ObjectField($"{(Sound)i}:", 
                         target.m_Sounds[i], typeof(AudioClip), false) as AudioClip;
-                        //ObjectField - это поле в инспекторе, в которое можно вводить объекты
+                    //ObjectField - это поле в инспекторе, в которое можно вводить объекты
+                    if (newClip != target.m_Sounds[i])
+                    {
+                        target.m_Sounds[i] = newClip;  //Он проверяет: действительно ли пользователь изменил значение в инспекторе
+                        EditorUtility.SetDirty(target); //  ВАЖНО
+                        //Что делает EditorUtility.SetDirty(target):
+                        //это говоришь Unity: “Этот объект изменился — обязательно сохрани его на диск”
+                    }
                 }
             }
         }

--- a/Assets/Scripts/_imported/LevelResultController.cs
+++ b/Assets/Scripts/_imported/LevelResultController.cs
@@ -23,6 +23,11 @@ namespace SpaceShooter
         [SerializeField] private Text m_TotalKills;
 
 
+        private void OnEnable()
+        {
+            m_PanelSuccess.gameObject.SetActive(false);
+            m_PanelFailure.gameObject.SetActive(false);
+        }
         /// <summary>
         /// Показываем окошко результатов. Выставляем нужные кнопочки в зависимости от успеха.
         /// </summary>


### PR DESCRIPTION
Added change detection and marked the Sounds ScriptableObject as dirty after AudioClip reassignment in the custom inspector.

This ensures Unity properly saves audio references to the asset file and prevents sound assignments from being lost after reload or restart.

Closes #66