### PR TITLE
Fix: correct upgrade availability toggle causing inconsistent behavior

### DIFF
--- a/Assets/Scenes/LevelMap.unity
+++ b/Assets/Scenes/LevelMap.unity
@@ -376,6 +376,10 @@ PrefabInstance:
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: Buy
       objectReference: {fileID: 0}
+    - target: {fileID: 4152819395694776590, guid: 6928a3de2a0aef24e8fef40bc99562ce, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4565392091321756785, guid: 6928a3de2a0aef24e8fef40bc99562ce, type: 3}
       propertyPath: m_Pivot.x
       value: 0
@@ -1009,19 +1013,19 @@ MonoBehaviour:
   m_DoNotDestroyOnLoad: 1
   save:
   - asset: {fileID: 11400000, guid: 1ac86bea5f2ab134f83e1430f5b0910d, type: 2}
-    level: 0
+    level: -1
     upgradeSO: {fileID: 11400000, guid: 0a5c374e4c3361c4bad497ce266e9b66, type: 2}
     name: 
   - asset: {fileID: 11400000, guid: 036f0c524b040db45a7d8ac0e32ea57f, type: 2}
-    level: 0
+    level: -1
     upgradeSO: {fileID: 11400000, guid: f38961f3f11c3344a98ca416ade272a1, type: 2}
     name: 
   - asset: {fileID: 11400000, guid: b86a3ea4c301db047aef08993a9bcd95, type: 2}
-    level: 0
+    level: -1
     upgradeSO: {fileID: 11400000, guid: 4c829f17800e8fb4499a4ec1319e8b0c, type: 2}
     name: 
   - asset: {fileID: 11400000, guid: 0f23a1f08dfd7b14f919496f73445ad6, type: 2}
-    level: 0
+    level: -1
     upgradeSO: {fileID: 11400000, guid: 20c8defb62d92f340835659ce408c6a4, type: 2}
     name: 
 --- !u!114 &793497654

--- a/Assets/Scripts/TowerAsset.cs
+++ b/Assets/Scripts/TowerAsset.cs
@@ -15,9 +15,26 @@ namespace TowerDefense
         public float radius;
         [SerializeField] private UpgradeAsset requiredUpgrade;
         [SerializeField] private int requiredUpgradeLevel;
-        public bool IsAvailable() => !requiredUpgrade ||
-            requiredUpgradeLevel <= Upgrades.GetUpgradeLevel(requiredUpgrade);
+        public bool IsAvailable()
+        {
+            Debug.Log("requiredUpgrade3333: " + requiredUpgrade);
+            Debug.Log("TowerAsset3333: " + name);
+            Debug.Log("requiredUpgrade == null3333: " + (requiredUpgrade == null));
+            Debug.Log("requiredUpgrade object3333: " + requiredUpgrade);
+            Debug.Log("requiredUpgrade name3333: " + (requiredUpgrade ? requiredUpgrade.name : "NULL"));
+            Debug.Log("Instance ID3333: " + (requiredUpgrade ? requiredUpgrade.GetInstanceID() : 0));
+            if (requiredUpgrade)
+            {
+                Debug.Log("Unity считает3333: НЕ null");
+            }
+            else
+            {
+                Debug.Log("Unity считает3333: null");
+            }
+            return !requiredUpgrade || requiredUpgradeLevel <= Upgrades.GetUpgradeLevel(requiredUpgrade);
+        }
         public TowerAsset[] m_UpgradesTo;
+
     }
 }
 

--- a/Assets/Scripts/Upgrades/BuyUpgrade.cs
+++ b/Assets/Scripts/Upgrades/BuyUpgrade.cs
@@ -19,7 +19,11 @@ namespace TowerDefense
         {
             ugradeIcon.sprite = asset.sprite;
             var savedLevel = Upgrades.GetUpgradeLevel(asset);
-           
+
+            if (savedLevel < 0)
+            {
+                savedLevel = 0;
+            }
             if (savedLevel >= asset.costByLevel.Length)
             {
                 level.text = $"а: {savedLevel} (Max)";
@@ -33,6 +37,7 @@ namespace TowerDefense
             {
                 level.text = $"Lvl: {savedLevel + 1}";
                 costNumber = asset.costByLevel[savedLevel];
+
                 costText.text = costNumber.ToString();
             }
         }

--- a/Assets/Scripts/Upgrades/Upgrades.cs
+++ b/Assets/Scripts/Upgrades/Upgrades.cs
@@ -12,7 +12,7 @@ namespace TowerDefense
         public class UpgradeSave
         {
             public UpgradeAsset asset;
-            public int level = 0;
+            public int level;
             public TowerUpgrade upgradeSO;   // ссылка на RadiusUpgrade, DamageUpgrade и т.д.
             public string name; // если нужно для UI, можно оставить
         }
@@ -22,7 +22,11 @@ namespace TowerDefense
         private new void Awake()
         {
             base.Awake();
-
+            for (int i = 0; i < Instance.save.Length; i++)
+            {
+                Debug.Log("qwerty GetUpgradeLevel INITIAL = " + Instance.save[i].level);
+            }
+               
             UpgradeSave[] loaded = null;
             Saver<UpgradeSave[]>.TryLoad(filename, ref loaded);
 
@@ -47,8 +51,9 @@ namespace TowerDefense
             {
                 if (upgrade.asset == asset)
                 {
+                    Debug.Log("qwerty BuyUpgrade level BEFORE" + upgrade.level);
                     upgrade.level += 1;
-                   
+                    Debug.Log("qwerty BuyUpgrade level AFTER" + upgrade.level);
                     Saver<UpgradeSave[]>.Save(filename, Instance.save);
                    
                 }
@@ -96,6 +101,7 @@ namespace TowerDefense
                     Debug.Log("PARAM NAME = " + asset.name);
                     //UpgradeAsset-Ы ДАННОГО МАССИВА ЭТОТ МЕТОД БЕРЁТ ИЗ ИНСПЕКТОРА,
                     //НЕСМОТРЯ НА ТО ЧТО ФАЙЛ upgrade.dat ЕЩЁ НЕ СОЗДАН.
+                    Debug.Log("qwerty GetUpgradeLevel" + Instance.save[i].level);
                     return Instance.save[i].level;
                 }
             }


### PR DESCRIPTION
Adjusted inspector setting for upgrade availability check. This prevents incorrect multiple tower processing during upgrade clicks.

Part of #37 (debugging sub-issue)