### PR TITLE
Fix upgrade first-click issue by normalizing negative level state

### DIFF
--- a/Assets/Scripts/Upgrades/Upgrades.cs
+++ b/Assets/Scripts/Upgrades/Upgrades.cs
@@ -52,6 +52,7 @@ namespace TowerDefense
                 if (upgrade.asset == asset)
                 {
                     Debug.Log("qwerty BuyUpgrade level BEFORE" + upgrade.level);
+                    if (upgrade.level < 0) upgrade.level = 0;
                     upgrade.level += 1;
                     Debug.Log("qwerty BuyUpgrade level AFTER" + upgrade.level);
                     Saver<UpgradeSave[]>.Save(filename, Instance.save);


### PR DESCRIPTION
Fixed an issue where upgrades in LevelMap did not respond to the first mouse click. After previous fix, upgrade entries could end up with an invalid state (level < 0), which caused the click handling logic to require a second interaction before applying the upgrade. Added a guard in BuyUpgrade to normalize invalid values: if (upgrade.level < 0) upgrade.level = 0;
This ensures consistent upgrade state and correct behavior on the first click.

Related to #37