### PR TITLE
Fix incorrect life reduction when upgrade level is negative

### DIFF
--- a/Assets/Prefabs/Polymorphism - Upgrades/HealthUpgrade.cs
+++ b/Assets/Prefabs/Polymorphism - Upgrades/HealthUpgrade.cs
@@ -13,8 +13,8 @@ namespace TowerDefense
 
         public override void ApplyPlayer(Player player, int level)
         {
-            if(level > 0 ) player.NumLives += multipliersByLevel[Mathf.Clamp(level - 1, 0, multipliersByLevel.Length - 1)];
-            Debug.Log(multipliersByLevel[Mathf.Clamp(level - 1, 0, multipliersByLevel.Length - 1)]+"444");
+            if (level > 0) player.NumLives += multipliersByLevel[Mathf.Clamp(level - 1, 0, multipliersByLevel.Length - 1)];
+            Debug.Log(multipliersByLevel[Mathf.Clamp(level - 1, 0, multipliersByLevel.Length - 1)] + "444");
             Debug.Log(player.NumLives +"444");
         }
     }

--- a/Assets/Prefabs/Upgrades/HealthUpgrade.asset
+++ b/Assets/Prefabs/Upgrades/HealthUpgrade.asset
@@ -13,4 +13,5 @@ MonoBehaviour:
   m_Name: HealthUpgrade
   m_EditorClassIdentifier: 
   sprite: {fileID: 21300000, guid: ae93735604fc8d04e8159ac66b724f1f, type: 3}
-  costByLevel: 0100000001000000010000000500000006000000
+  isEgyptTowerUpgrade: 0
+  costByLevel: 0100000001000000010000000900000006000000

--- a/Assets/Scripts/TDPlayer.cs
+++ b/Assets/Scripts/TDPlayer.cs
@@ -25,7 +25,10 @@ namespace TowerDefense
         private void Start()
         {
             var level = Upgrades.GetUpgradeLevel(healthUpgrade);
-            TakeDamage(-level * 5);
+            if(level > 0)
+            {
+                TakeDamage(-level * 5);
+            }
         }
 
         private int m_gold = 135;


### PR DESCRIPTION
Fixed an issue where player health was decreasing when applying an upgrade with a negative level.

Previously, the following logic was used:
TakeDamage(-level * 5)

When level < 0, this resulted in positive damage being applied, reducing player lives unintentionally.

Added a guard condition:
if (level > 0)

Now the health bonus is applied only when the upgrade level is valid (positive), preventing unintended life reduction.

Related to #37