### PR TITLE
Fix lives duplication and refactor health upgrade application flow

### DIFF
--- a/Assets/Prefabs/Polymorphism - Upgrades/HealthUpgrade.cs
+++ b/Assets/Prefabs/Polymorphism - Upgrades/HealthUpgrade.cs
@@ -9,13 +9,27 @@ namespace TowerDefense
     public class HealthUpgrade : TowerUpgrade
     {
         [SerializeField] private int[] multipliersByLevel;
-        //= { 2, 3, 4, 5, 6, 7 }
+        private int lastAppliedLevel = 0;
 
-        public override void ApplyPlayer(Player player, int level)
+        public override void ApplyPlayer(int level)
         {
-            if (level > 0) player.NumLives += multipliersByLevel[Mathf.Clamp(level - 1, 0, multipliersByLevel.Length - 1)];
-            Debug.Log(multipliersByLevel[Mathf.Clamp(level - 1, 0, multipliersByLevel.Length - 1)] + "444");
-            Debug.Log(player.NumLives +"444");
+            if (level <= lastAppliedLevel) return;
+
+            int delta = 0;
+
+            for (int i = lastAppliedLevel + 1; i <= level; i++)
+            {
+                delta += multipliersByLevel[Mathf.Clamp(i - 1, 0, multipliersByLevel.Length - 1)];
+            }
+
+            lastAppliedLevel = level;
+
+
+            HealthUpgradeBonusSaver.bonus += delta;
+            Debug.Log("devil " + delta);
+            Debug.Log("devil " + lastAppliedLevel);
+            HealthUpgradeBonusSaver.Instance.ShowHowMuchIsBonus();
+            delta = 0;
         }
     }
 }

--- a/Assets/Prefabs/Polymorphism - Upgrades/Health_Upgrade.asset
+++ b/Assets/Prefabs/Polymorphism - Upgrades/Health_Upgrade.asset
@@ -12,4 +12,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 63fed0dd98651804890e15ca56aa15ab, type: 3}
   m_Name: Health_Upgrade
   m_EditorClassIdentifier: 
-  multipliersByLevel: 0300000006000000090000000c000000
+  multipliersByLevel: 03000000040000000500000006000000

--- a/Assets/Prefabs/Polymorphism - Upgrades/MageUpgrade.cs
+++ b/Assets/Prefabs/Polymorphism - Upgrades/MageUpgrade.cs
@@ -11,7 +11,7 @@ namespace TowerDefense
         [SerializeField] private int[] multipliersByLevel;
         //= { 2, 3, 4, 5, 6, 7 }
 
-        public override void ApplyPlayer(Player player, int level)
+        public override void ApplyPlayer(int level)
         {
            
         }

--- a/Assets/Prefabs/Polymorphism - Upgrades/TowerUpgrade.cs
+++ b/Assets/Prefabs/Polymorphism - Upgrades/TowerUpgrade.cs
@@ -9,7 +9,7 @@ namespace TowerDefense
     public abstract class TowerUpgrade : ScriptableObject
     {
         public virtual void Apply(Tower tower, int level) { }
-        public virtual void ApplyPlayer(Player player, int level) { }
+        public virtual void ApplyPlayer(int level) { }
         public virtual void Egypt_Tower_Apply(Tower tower, int level) { }
     }
 }

--- a/Assets/Scenes/LevelMap.unity
+++ b/Assets/Scenes/LevelMap.unity
@@ -931,6 +931,7 @@ GameObject:
   - component: {fileID: 793497652}
   - component: {fileID: 793497653}
   - component: {fileID: 793497654}
+  - component: {fileID: 793497655}
   m_Layer: 0
   m_Name: MapLevelController
   m_TagString: Untagged
@@ -1038,6 +1039,19 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 54f4f54b41bdce44fadf4e467f988806, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_DoNotDestroyOnLoad: 1
+--- !u!114 &793497655
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 793497649}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fc14d2a61bb4514eba5ab57371e742f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_DoNotDestroyOnLoad: 1

--- a/Assets/Scripts/MapCompletion.cs
+++ b/Assets/Scripts/MapCompletion.cs
@@ -115,10 +115,10 @@ namespace TowerDefense
             }
 
             // Теперь безопасно применяем к Player
-            if (Player.Instance != null)
-            {
-                Player.Instance.ApplyPlayerUpgrades();
-            }
+            //if (Player.Instance != null)
+            //{
+            //    Player.Instance.ApplyPlayerUpgrades();
+            //}
 
             // пересчёт totalScore и т.д.
         }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -15,31 +15,11 @@ namespace SpaceShooter
     /// </summary>
     public class Player : MonoSingleton<Player>
     {
-        protected override void Awake()
-        {
-            base.Awake();
-
-            Debug.Log("Awake base lives = " + baseNumLives);
-
-            if (m_NumLives <= 0)
-                m_NumLives = baseNumLives; // без события
-        }
-
-        public void UpdateNumLivesInBranchLevels()
-        {
-            // Затем сразу загружаем из сохранения, если MapCompletion уже готов
-            if (MapCompletion.Instance != null && MapCompletion.Instance.Data != null)
-            {
-                Debug.Log("Load from save = " + MapCompletion.Instance.Data.numLivesTotal);
-                NumLives = MapCompletion.Instance.Data.numLivesTotal;
-            }
-        }
-
         private int baseNumLives = 10;
-      
         private static int m_NumLives;
-        public int NumLives 
-        {  
+
+        public int NumLives
+        {
             get { return m_NumLives; }
             set
             {
@@ -51,51 +31,45 @@ namespace SpaceShooter
         public event Action OnPlayerDead;
 
         [SerializeField] private SpaceShip m_Ship;
-        public SpaceShip ActiveShip => m_Ship;
-
         [SerializeField] private SpaceShip m_PlayerShipPrefab;
 
-        //[SerializeField] private CameraController m_CameraController;
-        //[SerializeField] private MovementController m_MovementController;
-        [SerializeField] private GameObject loosePanel;
-        public GameObject victoryPanel;
-        [SerializeField] protected Tower towerPrefab;
+        protected override void Awake()
+        {
+            base.Awake();
+
+            if (m_NumLives <= 0)
+                m_NumLives = baseNumLives; // без события
+        }
 
         private void Start()
         {
-            if (m_Ship)
-                SubscribeToShip(m_Ship);
-            ApplyPlayerUpgrades();
+            if (m_Ship) SubscribeToShip(m_Ship);
         }
 
-        public void ApplyPlayerUpgrades()
+        private void OnEnable()
         {
-            if (Upgrades.Instance == null || Upgrades.Instance.save == null) return;
-
-            // Сброс к базовому значению (важно!)
-            //NumLives = baseNumLives;   // должно быть какое-то базовое значение
-
-            foreach (var savedUpgrade in Upgrades.Instance.save)
-            {
-                if (savedUpgrade.upgradeSO != null)
-                {
-                    savedUpgrade.upgradeSO.ApplyPlayer(this, savedUpgrade.level);
-                }
-            }
-            Debug.Log("ApplyPlayerUpgrades called");
+            // Сразу прмиенить апргрейды
+            NumLives += HealthUpgradeBonusSaver.bonus;
         }
+
+        //public void ApplyPlayerUpgrades()
+        //{
+        //    if (Upgrades.Instance == null || Upgrades.Instance.save == null) return; // Сброс к базовому значению (важно!) 
+        //    //NumLives = baseNumLives; 
+        //    // должно быть какое-то базовое значение
+        //    foreach (var savedUpgrade in Upgrades.Instance.save) 
+        //    {
+        //        if (savedUpgrade.upgradeSO != null) 
+        //        {
+        //            savedUpgrade.upgradeSO.ApplyPlayer(savedUpgrade.level);
+        //        } 
+        //    } 
+        //}
 
         private void SubscribeToShip(SpaceShip ship)
         {
             ship.EventOnDeath.RemoveListener(OnShipDeath);
             ship.EventOnDeath.AddListener(OnShipDeath);
-        }
-
-        protected override void OnDestroy()
-        {
-            base.OnDestroy();
-            if (m_Ship != null)
-                m_Ship.EventOnDeath.RemoveListener(OnShipDeath);
         }
 
         private void OnShipDeath()
@@ -107,7 +81,6 @@ namespace SpaceShooter
             else
             {
                 LevelSequenceController.Instance.FinishCurrentLevel(false);
-                //GameReset.ResetStatics();
                 SceneManager.LoadScene(SceneManager.GetActiveScene().name, LoadSceneMode.Single);
             }
         }
@@ -118,17 +91,34 @@ namespace SpaceShooter
             m_Ship = newPlayerShip.GetComponent<SpaceShip>();
             m_Ship.EventOnDeath.AddListener(OnShipDeath);
         }
-            
-        #region Score (current level only)
 
-        public int Score { get; private set; }
+       
 
-        public int NumKills { get; private set; }
 
-        public void AddKill()
+
+
+        [SerializeField] private GameObject loosePanel;
+        public GameObject victoryPanel;
+        [SerializeField] protected Tower towerPrefab;
+        public SpaceShip ActiveShip => m_Ship;
+
+        //public void UpdateNumLivesInBranchLevels()
+        //{
+        //    if (MapCompletion.Instance != null && MapCompletion.Instance.Data != null)
+        //    {
+        //        NumLives = MapCompletion.Instance.Data.numLivesTotal;
+        //    }
+        //}
+
+        protected override void OnDestroy()
         {
-            NumKills++;
+            base.OnDestroy();
+            if (m_Ship != null)
+                m_Ship.EventOnDeath.RemoveListener(OnShipDeath);
         }
+
+        #region Score (current level only)
+        public int Score { get; private set; }
 
         public void AddScore(int num)
         {

--- a/Assets/Scripts/TDPlayer.cs
+++ b/Assets/Scripts/TDPlayer.cs
@@ -22,14 +22,7 @@ namespace TowerDefense
 
       
 
-        private void Start()
-        {
-            var level = Upgrades.GetUpgradeLevel(healthUpgrade);
-            if(level > 0)
-            {
-                TakeDamage(-level * 5);
-            }
-        }
+       
 
         private int m_gold = 135;
         public int Gold { get { return m_gold; } set { m_gold = value; } }
@@ -70,6 +63,7 @@ namespace TowerDefense
 
         public void ReduceLife(int numLives_damage, string enemyName)
         {
+            Debug.Log("SET LIVES 5 : " + numLives_damage);
             TakeDamage(numLives_damage);
             OnLifeUpdate?.Invoke(Player.Instance.NumLives);
         }

--- a/Assets/Scripts/Upgrades/HealthUpgradeBonusSaver.cs
+++ b/Assets/Scripts/Upgrades/HealthUpgradeBonusSaver.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using UnityEngine;
+using SpaceShooter;
+using UnityEngine.UI;
+
+namespace TowerDefense
+{
+    public class HealthUpgradeBonusSaver : MonoSingleton<HealthUpgradeBonusSaver>
+    {
+        public static int bonus = 0;
+        protected override void Awake()
+        {
+            base.Awake(); // ВАЖНО!
+        }
+        public void ShowHowMuchIsBonus()
+        {
+            Debug.Log("devil " + bonus);
+        }
+    }
+}

--- a/Assets/Scripts/Upgrades/HealthUpgradeBonusSaver.cs.meta
+++ b/Assets/Scripts/Upgrades/HealthUpgradeBonusSaver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6fc14d2a61bb4514eba5ab57371e742f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Upgrades/Upgrades.cs
+++ b/Assets/Scripts/Upgrades/Upgrades.cs
@@ -47,8 +47,15 @@ namespace TowerDefense
 
         public static void BuyUpgrade(UpgradeAsset asset)
         {
+            //if (Player.Instance == null)
+            //{
+            //    Debug.LogError("Player.Instance is NULL");
+            //    return;
+            //}
             foreach (var upgrade in Instance.save)
             {
+                Debug.Log("SO NULL? " + (upgrade.upgradeSO == null));
+
                 if (upgrade.asset == asset)
                 {
                     Debug.Log("qwerty BuyUpgrade level BEFORE" + upgrade.level);
@@ -56,11 +63,15 @@ namespace TowerDefense
                     upgrade.level += 1;
                     Debug.Log("qwerty BuyUpgrade level AFTER" + upgrade.level);
                     Saver<UpgradeSave[]>.Save(filename, Instance.save);
-                   
+                    if (upgrade.upgradeSO != null)
+                    {
+                        upgrade.upgradeSO.ApplyPlayer(upgrade.level);
+                        Debug.Log("SO NAME: " + upgrade.upgradeSO.name);
+                        Debug.Log("SO TYPE: " + upgrade.upgradeSO.GetType().Name);
+                    } 
                 }
             }
         }
-
        
 
         public static int GetTotalCost()

--- a/Assets/Scripts/_imported/LevelResultController.cs
+++ b/Assets/Scripts/_imported/LevelResultController.cs
@@ -89,7 +89,7 @@ namespace SpaceShooter
         /// <returns></returns>
         private void UpdateCurrentLevelStats()
         {
-            TotalStats.numKills += Player.Instance.NumKills;
+            //TotalStats.numKills += Player.Instance.NumKills;
             TotalStats.time += LevelController.Instance.LevelTime;
             TotalStats.score += Player.Instance.Score;
 

--- a/Assets/Scripts/_imported/LevelSequenceController.cs
+++ b/Assets/Scripts/_imported/LevelSequenceController.cs
@@ -73,7 +73,7 @@ namespace SpaceShooter
         //mode -- режим загрузки(Single или Additive)
         private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
         {
-            if(Player.Instance)Player.Instance.UpdateNumLivesInBranchLevels();
+            //if(Player.Instance)Player.Instance.UpdateNumLivesInBranchLevels();
             if (scene.name == MainMenuSceneNickname)
             {
                 var map = FindObjectOfType<LevelDisplayController>();


### PR DESCRIPTION
Fix:
- Resolved issue where player lives were incorrectly duplicated on level load
- Removed legacy logic in TDPlayer.Start() that applied lives via TakeDamage(-level * 5)
- Prevented multiple re-application of upgrades across scenes

Refactor:
- Changed polymorphic method signature in HealthUpgrade: ApplyPlayer(Player player, int level) → ApplyPlayer(int level)
- Reworked upgrade logic to calculate incremental bonus and store it internally
- Removed Player.ApplyPlayerUpgrades() method and its usage
- Removed upgrade reapplication call from MapCompletion

Feature:
- Added HealthUpgradeBonusSaver MonoSingleton • Stores accumulated bonus lives from upgrades • Ensures consistent state across scenes • Attached to LevelMap (MapLevelController)

Behavior Change:
- Player lives are no longer recalculated from base value on each level load
- Bonus lives are now applied once and persisted via HealthUpgradeBonusSaver
- Final lives = previous lives + accumulated upgrade bonus

Result:
- Stable and predictable lives system
- No unintended stacking or duplication
- Clear separation between upgrade calculation and application

Fixes #37