### PR TITLE
Fix Time Ability (Slow) not working after Continue due to event subscription mismatch

### DIFF
--- a/Assets/Scripts/Abilities/Abilities.cs
+++ b/Assets/Scripts/Abilities/Abilities.cs
@@ -16,6 +16,7 @@ namespace TowerDefense
         private void OnEnable()
         {
             Enemy.OnEnemyKilled += OnEnemyKilledHandler;
+            m_IsTimeAbilityOnCooldown = false;
         }
         private void OnEnemyKilledHandler(Enemy enemy)
         {
@@ -110,8 +111,9 @@ namespace TowerDefense
                 }
                 //Unity находит всех врагов на сцене и каждому уменьшает скорость
             }
-              
 
+            EnemyWaveManager.OnEnemySpawn -= Slow;
+          
             EnemyWaveManager.OnEnemySpawn += Slow;  //подписка на новых врагов //каждый новый враг - автоматически замедляется
            
             yield return new WaitForSeconds(duration);  //ждём длительность эффекта //игра продолжает идти но этот метод "засыпает" на duration секунд


### PR DESCRIPTION
Resolved an issue where the Time Ability (Slow effect) stopped working after using Continue in the same game session. The root cause was an incorrect or missing re-subscription to EnemyWaveManager.OnEnemySpawn, which caused the Slow handler to not be properly invoked for newly spawned enemies.

The fix ensures the event subscription is reset correctly by explicitly unsubscribing and re-subscribing to OnEnemySpawn, preventing stale or inconsistent event state between gameplay sessions.

Additionally, reset the cooldown state flag (m_IsTimeAbilityOnCooldown) to ensure the ability is properly re-enabled when needed. This flag controls whether the ability can be used during cooldown.

Fixes #40