### PR TITLE
Fix ability upgrade activation logic for Radius_Upgrade

### DIFF
--- a/Assets/Prefabs/Polymorphism - Upgrades/HealthUpgrade.cs
+++ b/Assets/Prefabs/Polymorphism - Upgrades/HealthUpgrade.cs
@@ -26,8 +26,8 @@ namespace TowerDefense
 
 
             HealthUpgradeBonusSaver.bonus += delta;
-            Debug.Log("devil " + delta);
-            Debug.Log("devil " + lastAppliedLevel);
+            Debug.Log("555" + delta);
+            Debug.Log("555" + lastAppliedLevel);
             HealthUpgradeBonusSaver.Instance.ShowHowMuchIsBonus();
             delta = 0;
         }

--- a/Assets/Prefabs/Polymorphism - Upgrades/RadiusUpgrade.cs
+++ b/Assets/Prefabs/Polymorphism - Upgrades/RadiusUpgrade.cs
@@ -8,14 +8,14 @@ namespace TowerDefense
     [CreateAssetMenu(menuName = "Upgrades/Tower/Radius Upgrade")]
     public class RadiusUpgrade : TowerUpgrade
     {
-        [SerializeField] private float[] multipliersByLevel = { 1.3f, 1.6f, 2f, 3f, 4f, 5f };
+        [SerializeField] private float[] multipliersByLevel = { 2f, 3f, 4f, 5f, 6f, 7f };
 
         public override void Apply(Tower tower, int level)
         {
             if (level < 1 || level >= multipliersByLevel.Length) return;
 
             // Можно сделать публичный метод в Tower, чтобы не лезть в private поле
-            tower.ModifyRadius(multipliersByLevel[level - 1]);
+            RadiusUpgradeBonusSaver.radiusUpgradeBonus = multipliersByLevel[level - 1];
         }
     }
 }

--- a/Assets/Scripts/Abilities/Abilities.cs
+++ b/Assets/Scripts/Abilities/Abilities.cs
@@ -10,13 +10,13 @@ namespace TowerDefense
 {
     public class Abilities : MonoSingleton<Abilities>
     {
-        private UpgradeAsset usingThisAbilityAssetNow;
         private float divisor = 0;
 
         private void OnEnable()
         {
             Enemy.OnEnemyKilled += OnEnemyKilledHandler;
             m_IsTimeAbilityOnCooldown = false;
+            EnemyWaveManager.OnEnemySpawn += Slow;
         }
         private void OnEnemyKilledHandler(Enemy enemy)
         {
@@ -26,10 +26,7 @@ namespace TowerDefense
         private void OnDisable()
         {
             Enemy.OnEnemyKilled -= OnEnemyKilledHandler;
-
             EnemyWaveManager.OnEnemySpawn -= Slow;
-
-            m_IsTimeAbilityOnCooldown = false;
         }
 
         private void Update()
@@ -42,7 +39,6 @@ namespace TowerDefense
         }
         public bool IsUnlocked(UpgradeAsset abilityAsset)
         {
-            usingThisAbilityAssetNow = abilityAsset;
            return Upgrades.GetUpgradeLevel(abilityAsset) > 0;
         }
 
@@ -54,16 +50,16 @@ namespace TowerDefense
         //Button button -- кнопка, которую надо заблокировать
         //float duration -- сколько длится эффект(замедление)
         //float cooldown, сколько длится перезарядка
-        public void UseTimeAbility(MonoBehaviour runner, UnityEngine.UI.Button button, float duration, float cooldown)
+        public void UseTimeAbility(UpgradeAsset abilityAsset, MonoBehaviour runner, UnityEngine.UI.Button button, float duration, float cooldown)
         {
             if (m_IsTimeAbilityOnCooldown)
                 return;
           
 
             divisor = 1f;
-            if (Upgrades.GetUpgradeLevel(usingThisAbilityAssetNow) > 1)
+            if (Upgrades.GetUpgradeLevel(abilityAsset) > 0)
             {
-                for (int i = 1; i < Upgrades.GetUpgradeLevel(usingThisAbilityAssetNow); i++)
+                for (int i = 0; i < Upgrades.GetUpgradeLevel(abilityAsset); i++)
                 {
                     divisor /= 2;
                 }
@@ -113,7 +109,7 @@ namespace TowerDefense
             }
 
             EnemyWaveManager.OnEnemySpawn -= Slow;
-          
+
             EnemyWaveManager.OnEnemySpawn += Slow;  //подписка на новых врагов //каждый новый враг - автоматически замедляется
            
             yield return new WaitForSeconds(duration);  //ждём длительность эффекта //игра продолжает идти но этот метод "засыпает" на duration секунд
@@ -126,7 +122,7 @@ namespace TowerDefense
                 }
             }
 
-            EnemyWaveManager.OnEnemySpawn -= Slow; //отписка. больше НЕ замедляем новых врагов, если забыть это — будет баг!!!
+            //EnemyWaveManager.OnEnemySpawn -= Slow; //отписка. больше НЕ замедляем новых врагов, если забыть это — будет баг!!!
 
             //yield return new WaitForSeconds(cooldown); //ждём кулдаун. ещё пауза — уже для кнопки
 
@@ -189,7 +185,7 @@ namespace TowerDefense
         //private int m_DamagePoints = 0;
         //public int DamagePoints { get { return m_DamagePoints; } set { m_DamagePoints = value; } }
         //public int alreadySavedDamage = 0;
-        public void UseFireAbility()
+        public void UseFireAbility(UpgradeAsset abilityAsset)
         {
             int damage = m_FireAbility.Damage;
 
@@ -211,32 +207,23 @@ namespace TowerDefense
 
                     if (enemy != null)
                     {
-                        Debug.Log("DAMAGE TO: " + enemy.name);
-                        Debug.Log("666 GetupgradeLevel= " + Upgrades.GetUpgradeLevel(usingThisAbilityAssetNow));
-                        if (Upgrades.GetUpgradeLevel(usingThisAbilityAssetNow) > 1)
+                        if (Upgrades.GetUpgradeLevel(abilityAsset) > 1)
                         {
-                            for(int i = 1; i < Upgrades.GetUpgradeLevel(usingThisAbilityAssetNow); i++)
+                            for(int i = 1; i < Upgrades.GetUpgradeLevel(abilityAsset); i++)
                             {
                                 damage += 2;
-                                Debug.Log($"666789 {i} = " + damage);
+                                Debug.Log($"asdf {i} = " + damage);
                             }
                         }
-                        Debug.Log("Damage without ENERGY ABILITY is: " + damage);
                         // ENERGY БОНУС
                         if (IsEnergyFull)
                         {
                             damage *= 2;
-                            Debug.Log("ENERGY BONUS ACTIVATED!");
                             ResetEnergy();
-                            Debug.Log("BECAUSE OF ENERGY ABILITY DAMAGE*2 = " + damage);
                         }
 
                         enemy.TakeDamage(damage, TDProjectile.DamageType.Magic);
-                        //m_DamagePoints = damage;
                         damage = m_FireAbility.Damage;
-                        //Debug.Log("666 1= " + m_DamagePoints);
-                        Debug.Log("666 2= " + damage);
-                       
                     }
                 }
             });

--- a/Assets/Scripts/Abilities/AbilitiesView.cs
+++ b/Assets/Scripts/Abilities/AbilitiesView.cs
@@ -57,14 +57,14 @@ namespace TowerDefense
             Debug.Log("Abilities: " + Abilities.Instance);
             Debug.Log("Button: " + m_TimeButton);
             Debug.Log("abilityManager = " + Abilities.Instance.name);
-            Abilities.Instance.UseTimeAbility(this, m_TimeButton, 5f, 5f);
+            Abilities.Instance.UseTimeAbility(abilityAsset, this, m_TimeButton, 5f, 5f);
         }
 
         [SerializeField] private FireAbility m_FireAbility;
         public void OnFireButtonClick()
         {
             Debug.Log("Abilities.Instance = " + Abilities.Instance);
-            Abilities.Instance.UseFireAbility();
+            Abilities.Instance.UseFireAbility(abilityAsset);
             TDPlayer.Instance.ChangeGold(-Abilities.Instance.FireAbilityGold);
         }
     }

--- a/Assets/Scripts/SpaceShip.cs
+++ b/Assets/Scripts/SpaceShip.cs
@@ -98,7 +98,6 @@ namespace SpaceShooter
         public void SetSlowMultiplier(float multiplier)
         {
             m_SlowMultiplier = multiplier;
-            Debug.Log("asdf666 "+ multiplier);
         }
 
         private void UpdateRigidbody()

--- a/Assets/Scripts/Tower.cs
+++ b/Assets/Scripts/Tower.cs
@@ -9,6 +9,7 @@ namespace TowerDefense
     public class Tower : MonoBehaviour
     {
         [SerializeField] private float m_Radius;
+        private float baseRadius;
         private float m_Lead = 0.3f;
         private Turret[] turrets;
         private Rigidbody2D target = null; //RigidBody2D знает всю свою физику, включая направление движения
@@ -27,23 +28,23 @@ namespace TowerDefense
 
         private void Start()
         {
+            baseRadius = m_Radius;
             // Сразу прмиенить апргрейды
             ApplyAllUpgrades();
-        }
-
-        public void ModifyRadius(float levelNumber)
-        {
-            m_Radius *= levelNumber;
+            m_Radius = baseRadius * RadiusUpgradeBonusSaver.radiusUpgradeBonus;
         }
 
         private void ApplyAllUpgrades()
         {
+            Debug.Log("666CURRENT LEVEL = ");
             if (Upgrades.Instance == null || Upgrades.Instance.save == null) return;
 
             foreach (var savedUpgrade in Upgrades.Instance.save)
             {
+                Debug.Log("666CURRENT LEVEL = " + Upgrades.Instance.save);
                 if (savedUpgrade.upgradeSO != null) // upgradeSO название поля, может отличаться
                 {
+                    Debug.Log("666CURRENT LEVEL = " + savedUpgrade.level);
                     savedUpgrade.upgradeSO.Apply(this, savedUpgrade.level);
                     //В ЭТОЙ СТРОКЕ ПРОИСХОДИТ МАГИЯ!!!
                     //Проговорю всю цепочку действий:

--- a/Assets/Scripts/Upgrades/HealthUpgradeBonusSaver.cs
+++ b/Assets/Scripts/Upgrades/HealthUpgradeBonusSaver.cs
@@ -14,7 +14,16 @@ namespace TowerDefense
         }
         public void ShowHowMuchIsBonus()
         {
-            Debug.Log("devil " + bonus);
+            Debug.Log("555" + bonus);
+        }
+    }
+    public class RadiusUpgradeBonusSaver : MonoSingleton<RadiusUpgradeBonusSaver>
+    {
+        public static float radiusUpgradeBonus = 1f;
+       
+        protected override void Awake()
+        {
+            base.Awake(); // ВАЖНО!
         }
     }
 }

--- a/Assets/Scripts/Upgrades/Upgrades.cs
+++ b/Assets/Scripts/Upgrades/Upgrades.cs
@@ -17,6 +17,11 @@ namespace TowerDefense
             public string name; // если нужно для UI, можно оставить
         }
 
+        private void OnEnable()
+        {
+            Debug.Log("HealthUpgrade55ENABLED: " + name);
+        }
+
         [SerializeField] public UpgradeSave[] save;
 
         private new void Awake()
@@ -54,21 +59,15 @@ namespace TowerDefense
             //}
             foreach (var upgrade in Instance.save)
             {
-                Debug.Log("SO NULL? " + (upgrade.upgradeSO == null));
-
                 if (upgrade.asset == asset)
                 {
-                    Debug.Log("qwerty BuyUpgrade level BEFORE" + upgrade.level);
                     if (upgrade.level < 0) upgrade.level = 0;
                     upgrade.level += 1;
-                    Debug.Log("qwerty BuyUpgrade level AFTER" + upgrade.level);
                     Saver<UpgradeSave[]>.Save(filename, Instance.save);
                     if (upgrade.upgradeSO != null)
                     {
                         upgrade.upgradeSO.ApplyPlayer(upgrade.level);
-                        Debug.Log("SO NAME: " + upgrade.upgradeSO.name);
-                        Debug.Log("SO TYPE: " + upgrade.upgradeSO.GetType().Name);
-                    } 
+                    }
                 }
             }
         }


### PR DESCRIPTION
Originally, the first click on the Radius_Upgrade was intentionally designed to only unlock and display both Abilities in the level scene. The actual enemy slow effect was supposed to start working only beginning with the second click on the Radius_Upgrade.

The issue was caused by the following condition inside the Abilities system:

if (Upgrades.GetUpgradeLevel(abilityAsset) > 1)
{
    for (int i = 1; i < Upgrades.GetUpgradeLevel(abilityAsset); i++)
    {
        divisor /= 2;
    }
}

After the first purchase in LevelMap, BuyUpgrade changed the upgrade level from -1 to 1:

if (upgrade.level < 0) upgrade.level = 0;
upgrade.level += 1;

Because of this, the condition > 1 was not satisfied, so the slow effect never activated after the first click.

This behavior was not actually a bug, but rather part of the original architecture design that had later been forgotten, which caused confusion during debugging.

Fixed by updating the ability level checks to start from level 1 instead of level 2:

if (Upgrades.GetUpgradeLevel(abilityAsset) > 0)
{
    for (int i = 0; i < Upgrades.GetUpgradeLevel(abilityAsset); i++)
    {
        divisor /= 2;
    }
}

Fixes #65