### PR TITLE
Refactor player lives save system and improve upgrade persistence

### DIFF
--- a/Assets/Prefabs/Polymorphism - Upgrades/HealthUpgrade.cs
+++ b/Assets/Prefabs/Polymorphism - Upgrades/HealthUpgrade.cs
@@ -9,7 +9,7 @@ namespace TowerDefense
     public class HealthUpgrade : TowerUpgrade
     {
         [SerializeField] private int[] multipliersByLevel;
-        private int lastAppliedLevel = 0;
+        public static int lastAppliedLevel = 0;
 
         public override void ApplyPlayer(int level)
         {
@@ -22,11 +22,11 @@ namespace TowerDefense
                 delta += multipliersByLevel[Mathf.Clamp(i - 1, 0, multipliersByLevel.Length - 1)];
             }
 
-            lastAppliedLevel = level;
+           
 
 
-            HealthUpgradeBonusSaver.bonus += delta;
-            HealthUpgradeBonusSaver.Instance.ShowHowMuchIsBonus();
+            HealthUpgradeBonusSaver.bonus = delta;
+            HealthUpgradeBonusSaver.Instance.SetLastAppliedLevel(level);
             delta = 0;
         }
     }

--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -492,6 +492,50 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 657960191}
   m_CullTransparentMesh: 1
+--- !u!1 &698575894
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 698575896}
+  - component: {fileID: 698575895}
+  m_Layer: 0
+  m_Name: LevelInitializer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &698575895
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 698575894}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 043b4e91e9e26454f9dc483231d072f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &698575896
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 698575894}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.8228329, y: -0.9112098, z: -0.048527163}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &993733850
 GameObject:
   m_ObjectHideFlags: 0
@@ -1361,3 +1405,4 @@ SceneRoots:
   - {fileID: 1403399358}
   - {fileID: 1513411123}
   - {fileID: 1278431612}
+  - {fileID: 698575896}

--- a/Assets/Scripts/LevelInitializer.cs
+++ b/Assets/Scripts/LevelInitializer.cs
@@ -1,0 +1,56 @@
+﻿using SpaceShooter;
+using System.Collections;
+using TowerDefense;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace TowerDefense
+{
+    public class LevelInitializer : MonoBehaviour
+    {
+        public static LevelInitializer Instance;
+
+        private void Awake()
+        {
+            if (Instance != null)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+
+        private void OnEnable()
+        {
+            SceneManager.sceneLoaded += OnSceneLoaded;
+        }
+
+        private void OnDisable()
+        {
+            SceneManager.sceneLoaded -= OnSceneLoaded;
+        }
+
+        private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            StartCoroutine(Init());
+        }
+
+        private IEnumerator Init()
+        {
+            yield return new WaitUntil(() => Player.Instance != null);
+            yield return new WaitUntil(() => MapCompletion.Instance != null);
+
+            InitializeLevel();
+        }
+
+        private void InitializeLevel()
+        {
+            Player.Instance.NumLives += HealthUpgradeBonusSaver.bonus;
+            HealthUpgradeBonusSaver.bonus = 0;
+       
+            Debug.Log("LEVEL INITIALIZED");
+        }
+    }
+}

--- a/Assets/Scripts/LevelInitializer.cs.meta
+++ b/Assets/Scripts/LevelInitializer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 043b4e91e9e26454f9dc483231d072f6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MapCompletion.cs
+++ b/Assets/Scripts/MapCompletion.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 //Хранит в себе инфо о том, на сколько очков был выполнен каждый из уровней.
 //Инфо о завершении карты будет храниться внутри MapCompletion
@@ -11,6 +12,9 @@ namespace TowerDefense
     public class MapCompletion : MonoSingleton<MapCompletion>
     {
         public const string filename = "completion.dat";
+        private bool continueButtonWasPushed_Lives = true;
+        private bool continueButtonWasPushed_Gold = true;
+
 
         [Serializable]
         public class EpisodeScore
@@ -25,6 +29,7 @@ namespace TowerDefense
             public int unlockedLevels = 0;
             public int numLivesTotal;
             public int damageUpgrade;
+            public int currentGoldCount;
         }
 
         [SerializeField] private Episode[] allEpisodes;  // Сюда в инспекторе перетащить все Episode
@@ -34,7 +39,7 @@ namespace TowerDefense
         public CompletionData Data => data;
         public int UnlockedLevels => data.unlockedLevels;
 
-        public static void SaveEpisodeResult(int levelScore, int numLives)
+        public static void SaveEpisodeResult(int levelScore, int numLives, int currentGold)
         {
             if (Instance)
             {
@@ -49,7 +54,7 @@ namespace TowerDefense
                             Instance.data.unlockedLevels++;
                             Debug.Log("Saving lives = " + numLives);
                             Instance.data.numLivesTotal = numLives;
-                            //Instance.data.damageUpgrade = Abilities.Instance.DamagePoints;
+                            Instance.data.currentGoldCount = currentGold;
                             Saver<CompletionData>.Save(filename, Instance.data);
                         }
                     }
@@ -101,33 +106,39 @@ namespace TowerDefense
             }
         }
 
-        private void Start()   // именно Start, а не Awake!
+
+        private static TDPlayer tdPlayer;
+
+        private void OnEnable()
         {
-            Saver<CompletionData>.TryLoad(filename, ref data);
-
-            if (data == null)
-            {
-                data = new CompletionData();
-                // ... инициализация эпизодов ...
-                Player.Instance.NumLives = data.numLivesTotal;   // важно задать начальное
-                //Abilities.Instance.alreadySavedDamage = data.damageUpgrade;   // сохранённое значение апгрейднутого умения
-               
-            }
-
-            // Теперь безопасно применяем к Player
-            //if (Player.Instance != null)
-            //{
-            //    Player.Instance.ApplyPlayerUpgrades();
-            //}
-
-            // пересчёт totalScore и т.д.
+            SceneManager.sceneLoaded += OnSceneLoaded;
+            tdPlayer = FindObjectOfType<TDPlayer>();
         }
+        private void OnDisable()
+        {
+            SceneManager.sceneLoaded -= OnSceneLoaded;
+        }
+        private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            if (Player.Instance != null && continueButtonWasPushed_Lives == true)
+            {
+                Player.Instance.NumLives = data.numLivesTotal;
+                continueButtonWasPushed_Lives = false;
+            }
+            if (tdPlayer != null && continueButtonWasPushed_Gold && data.currentGoldCount != 0)
+            {
+                tdPlayer.Gold = data.currentGoldCount;
+                continueButtonWasPushed_Gold = false;
+            }
+        }
+
+
 
         public int GetEpisodeScore(Episode m_episode)
         {
             foreach (var data in data.episodes)
             {
-                if(data.episode == m_episode)
+                if (data.episode == m_episode)
                 {
                     return data.score;
                 }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using TowerDefense;
+using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using static TowerDefense.TextUpdate;
@@ -39,17 +40,13 @@ namespace SpaceShooter
 
             if (m_NumLives <= 0)
                 m_NumLives = baseNumLives; // без события
+
+            TDPlayer.RaiseLifeUpdate(m_NumLives);
         }
 
         private void Start()
         {
             if (m_Ship) SubscribeToShip(m_Ship);
-        }
-
-        private void OnEnable()
-        {
-            // Сразу прмиенить апргрейды
-            NumLives += HealthUpgradeBonusSaver.bonus;
         }
 
         //public void ApplyPlayerUpgrades()
@@ -91,11 +88,6 @@ namespace SpaceShooter
             m_Ship = newPlayerShip.GetComponent<SpaceShip>();
             m_Ship.EventOnDeath.AddListener(OnShipDeath);
         }
-
-       
-
-
-
 
         [SerializeField] private GameObject loosePanel;
         public GameObject victoryPanel;

--- a/Assets/Scripts/TDLevelController.cs
+++ b/Assets/Scripts/TDLevelController.cs
@@ -8,8 +8,6 @@ namespace TowerDefense
     {
         private int levelScore = 3;
        
-        private int totalCount = 0;
-       
         protected override void Start()
         {
             base.Start();
@@ -35,9 +33,7 @@ namespace TowerDefense
 
             print(levelScore);
 
-            totalCount = TDPlayer.Instance.Gold;
-
-            MapCompletion.SaveEpisodeResult(levelScore, Player.Instance.NumLives);
+            MapCompletion.SaveEpisodeResult(levelScore, Player.Instance.NumLives, TDPlayer.Instance.Gold);
         }
 
         //отписка 

--- a/Assets/Scripts/TDPlayer.cs
+++ b/Assets/Scripts/TDPlayer.cs
@@ -20,11 +20,17 @@ namespace TowerDefense
 
         [SerializeField] private UpgradeAsset healthUpgrade;
 
-      
-
        
+        protected override void Awake()
+        {
+            base.Awake();
 
-        private int m_gold = 135;
+            if (m_gold <= 0)
+                m_gold = baseGoldCount; 
+        }
+
+        private int baseGoldCount = 135;
+        private static int m_gold;
         public int Gold { get { return m_gold; } set { m_gold = value; } }
 
         private event Action<int> OnGoldUpdate;
@@ -32,8 +38,7 @@ namespace TowerDefense
         {
             Debug.Log("GoldChanged INVOKE from: " + Environment.StackTrace);
             OnGoldUpdate += act;
-            act(Instance.m_gold);
-            Debug.Log(Instance.m_gold);
+            act(Gold);
         }
         public void GoldUpdateUnsubscribe(Action<int> act)
         {

--- a/Assets/Scripts/Upgrades/HealthUpgradeBonusSaver.cs
+++ b/Assets/Scripts/Upgrades/HealthUpgradeBonusSaver.cs
@@ -12,9 +12,13 @@ namespace TowerDefense
         {
             base.Awake(); // ВАЖНО!
         }
-        public void ShowHowMuchIsBonus()
+        public void SetLastAppliedLevel(int level)
         {
-            Debug.Log("bonus is " + bonus);
+            if (bonus != 0) return;
+            else
+            {
+                HealthUpgrade.lastAppliedLevel = level;
+            }
         }
     }
     public class RadiusUpgradeBonusSaver : MonoSingleton<RadiusUpgradeBonusSaver>


### PR DESCRIPTION
Reworked player lives save/load system
Player lives are now preserved correctly between scenes Health upgrades can now be applied at any moment during gameplay Fixed issue where bonus lives were being reapplied multiple times Current lives now persist correctly between gameplay sessions Improved interaction flow between HealthUpgrade and HealthUpgradeBonusSaver Added LevelInitializer.cs for safer scene initialization and runtime setup Improved gold/score save logic

Known issue:
Gold amount is still not persisted correctly between gameplay sessions and resets after restarting the game
