### PR TITLE
Fix Energy Bar reset behavior for Fire Ability

### DIFF
--- a/Assets/Scripts/Abilities/Abilities.cs
+++ b/Assets/Scripts/Abilities/Abilities.cs
@@ -11,22 +11,31 @@ namespace TowerDefense
     public class Abilities : MonoSingleton<Abilities>
     {
         private float divisor = 0;
+        public static bool m_BlockEnergyGain = true;
 
         private void OnEnable()
         {
             Enemy.OnEnemyKilled += OnEnemyKilledHandler;
             m_IsTimeAbilityOnCooldown = false;
             EnemyWaveManager.OnEnemySpawn += Slow;
+            m_BlockEnergyGain = false;
         }
         private void OnEnemyKilledHandler(Enemy enemy)
         {
-            AddEnergy(20f); 
+            if (m_BlockEnergyGain)
+                return;
+            else if(enemy != null && m_BlockEnergyGain == false)
+            {
+                AddEnergy(20f);
+            }
         }
       
         private void OnDisable()
         {
             Enemy.OnEnemyKilled -= OnEnemyKilledHandler;
             EnemyWaveManager.OnEnemySpawn -= Slow;
+            m_BlockEnergyGain = true;
+            m_IsTimeAbilityOnCooldown = false;
         }
 
         private void Update()
@@ -249,8 +258,8 @@ namespace TowerDefense
         public void ResetEnergy()
         {
             m_Energy = 0f;
+            m_BlockEnergyGain = true;
         }
-
     }
 }
 

--- a/Assets/Scripts/_imported/Destructible.cs
+++ b/Assets/Scripts/_imported/Destructible.cs
@@ -80,6 +80,7 @@ namespace SpaceShooter
 
                 if (enemy != null)
                 {
+                    Abilities.m_BlockEnergyGain = false;
                     Enemy.OnEnemyKilled?.Invoke(enemy);
                 }
             }


### PR DESCRIPTION
* Improved Energy Bar behavior for the UseFireAbility skill
* Fixed issue where the energy bar was resetting to 20% instead of 0%
* Energy now resets correctly to 0 after ability usage
* Energy bar now properly refills by 20% for each defeated enemy
* Adjusted event handling logic for enemy kill energy gain

Fixes #47