### PR TITLE
Refactor gold state updates and fix save/load synchronization

### DIFF
--- a/Assets/Scripts/MapCompletion.cs
+++ b/Assets/Scripts/MapCompletion.cs
@@ -47,8 +47,8 @@ namespace TowerDefense
                 { //Сохранение новых очков прохождения и жизней
                     if (item.episode == LevelSequenceController.Instance.CurrentEpisode)
                     {
-                        if (levelScore > item.score)
-                        {
+                        //if (levelScore > item.score)
+                        //{
                             Instance.totalScore += levelScore - item.score;
                             item.score = levelScore;
                             Instance.data.unlockedLevels++;
@@ -56,7 +56,7 @@ namespace TowerDefense
                             Instance.data.numLivesTotal = numLives;
                             Instance.data.currentGoldCount = currentGold;
                             Saver<CompletionData>.Save(filename, Instance.data);
-                        }
+                        //}
                     }
                 }
             }
@@ -82,9 +82,7 @@ namespace TowerDefense
         private new void Awake()
         {
             base.Awake();
-
             Saver<CompletionData>.TryLoad(filename, ref data);
-
             if (data == null)
             {
                 data = new CompletionData();
@@ -106,13 +104,9 @@ namespace TowerDefense
             }
         }
 
-
-        private static TDPlayer tdPlayer;
-
         private void OnEnable()
         {
             SceneManager.sceneLoaded += OnSceneLoaded;
-            tdPlayer = FindObjectOfType<TDPlayer>();
         }
         private void OnDisable()
         {
@@ -125,9 +119,18 @@ namespace TowerDefense
                 Player.Instance.NumLives = data.numLivesTotal;
                 continueButtonWasPushed_Lives = false;
             }
-            if (tdPlayer != null && continueButtonWasPushed_Gold && data.currentGoldCount != 0)
+
+            if (TDPlayer.Instance != null && continueButtonWasPushed_Gold)
             {
-                tdPlayer.Gold = data.currentGoldCount;
+                if (data.currentGoldCount > 0)
+                {
+                    TDPlayer.Instance.Gold = data.currentGoldCount;
+                }
+                else
+                {
+                    TDPlayer.Instance.Gold = 135;
+                }
+
                 continueButtonWasPushed_Gold = false;
             }
         }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -18,6 +18,7 @@ namespace SpaceShooter
     {
         private int baseNumLives = 10;
         private static int m_NumLives;
+        private static int m_gold;
 
         public int NumLives
         {
@@ -26,6 +27,13 @@ namespace SpaceShooter
             {
                 m_NumLives = Mathf.Max(0, value);
                 TDPlayer.RaiseLifeUpdate(m_NumLives); // просто вызываем событие
+            }
+        }
+        public int Gold { get { return m_gold; }
+            set
+            {
+                m_gold = value;
+                TDPlayer.RaiseGoldUpdate(m_gold); // просто вызываем событие
             }
         }
 
@@ -40,6 +48,7 @@ namespace SpaceShooter
 
             if (m_NumLives <= 0)
                 m_NumLives = baseNumLives; // без события
+            
 
             TDPlayer.RaiseLifeUpdate(m_NumLives);
         }

--- a/Assets/Scripts/TDPlayer.cs
+++ b/Assets/Scripts/TDPlayer.cs
@@ -20,27 +20,22 @@ namespace TowerDefense
 
         [SerializeField] private UpgradeAsset healthUpgrade;
 
-       
+        private int baseGoldCount = 135;
         protected override void Awake()
         {
             base.Awake();
-
-            if (m_gold <= 0)
-                m_gold = baseGoldCount; 
+            if (Gold <= 0)
+                Gold = baseGoldCount;
         }
 
-        private int baseGoldCount = 135;
-        private static int m_gold;
-        public int Gold { get { return m_gold; } set { m_gold = value; } }
-
-        private event Action<int> OnGoldUpdate;
-        public void GoldUpdateSubscribe(Action<int> act)
+        public static event Action<int> OnGoldUpdate;
+        public static void GoldUpdateSubscribe(Action<int> act)
         {
             Debug.Log("GoldChanged INVOKE from: " + Environment.StackTrace);
             OnGoldUpdate += act;
-            act(Gold);
+            act(Player.Instance.Gold);
         }
-        public void GoldUpdateUnsubscribe(Action<int> act)
+        public static void GoldUpdateUnsubscribe(Action<int> act)
         {
             OnGoldUpdate -= act;
         }
@@ -50,6 +45,12 @@ namespace TowerDefense
         {
             OnLifeUpdate?.Invoke(lives);
         }
+
+        public static void RaiseGoldUpdate(int gold) //метод-обёртка внутри TDPlayer, который будет вызывать событие.
+        {
+            OnGoldUpdate?.Invoke(gold);
+        }
+
         public static void LifeUpdateSubscribe(Action<int> act)
         {
             OnLifeUpdate += act;
@@ -62,8 +63,8 @@ namespace TowerDefense
 
         public void ChangeGold(int change)
         {
-            m_gold += change;
-            OnGoldUpdate?.Invoke(m_gold);
+            Gold += change;
+            OnGoldUpdate?.Invoke(Gold);
         }
 
         public void ReduceLife(int numLives_damage, string enemyName)

--- a/Assets/Scripts/TextUpdate.cs
+++ b/Assets/Scripts/TextUpdate.cs
@@ -22,7 +22,7 @@ namespace TowerDefense
             switch (source)
             {
                 case UpdateSource.Gold:
-                    TDPlayer.Instance.GoldUpdateSubscribe(UpdateText);
+                    TDPlayer.GoldUpdateSubscribe(UpdateText);
                     break;
                 case UpdateSource.Life:
                     TDPlayer.LifeUpdateSubscribe(UpdateText);
@@ -35,7 +35,7 @@ namespace TowerDefense
             switch (source)
             {
                 case UpdateSource.Gold:
-                    TDPlayer.Instance.GoldUpdateUnsubscribe(UpdateText);
+                    TDPlayer.GoldUpdateUnsubscribe(UpdateText);
                     break;
                 case UpdateSource.Life:
                     TDPlayer.LifeUpdateUnsubscribe(UpdateText);

--- a/Assets/Scripts/TowerBuyControl.cs
+++ b/Assets/Scripts/TowerBuyControl.cs
@@ -34,12 +34,12 @@ namespace TowerDefense
 
         private void OnEnable()
         {
-            TDPlayer.Instance.GoldUpdateSubscribe(GoldStatusCheck);
+            TDPlayer.GoldUpdateSubscribe(GoldStatusCheck);
         }
 
         private void OnDisable()
         {
-            TDPlayer.Instance.GoldUpdateUnsubscribe(GoldStatusCheck);
+            TDPlayer.GoldUpdateUnsubscribe(GoldStatusCheck);
         }
 
         public void SetTowerAsset(TowerAsset asset)


### PR DESCRIPTION
- Fixed gold save/load flow between game sessions

- Refactored gold update system to mirror life update architecture

- Added static gold event system:
  - OnGoldUpdate
  - GoldUpdateSubscribe()
  - GoldUpdateUnsubscribe()

- Added RaiseGoldUpdate() wrapper method for centralized gold event invocation

- Updated Gold property setter to automatically invoke gold update events

- Added default gold initialization in TDPlayer.Awake()

- Fixed UI gold subscriptions to use static TDPlayer gold update methods

- Updated MapCompletion save logic:
  - removed score condition restriction for saving completion data
  - gold and lives are now always written to save data

- Fixed gold overwrite issue during scene loading:
  - prevented saved value 0 from overwriting default starting gold

- Improved synchronization between gameplay state, UI, and persistent save data

Fixes #88